### PR TITLE
Fix static asset serving

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -2,10 +2,16 @@ import json
 import os
 from fastapi import FastAPI, WebSocket, WebSocketDisconnect
 from fastapi.responses import HTMLResponse
+from fastapi.staticfiles import StaticFiles
 from .docker_tools import DockerManager
 from .ai_agent import AIAgent
 
 app = FastAPI()
+app.mount(
+    "/static",
+    StaticFiles(directory=os.path.join(os.path.dirname(__file__), "..", "frontend")),
+    name="static",
+)
 
 docker_manager = None
 ai_agent = None

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <title>DevOps AI</title>
-    <link rel="stylesheet" href="style.css">
+    <link rel="stylesheet" href="/static/style.css">
 </head>
 <body>
 <div id="container">
@@ -15,6 +15,6 @@
         <pre id="terminal-log"></pre>
     </div>
 </div>
-<script src="app.js"></script>
+<script src="/static/app.js"></script>
 </body>
 </html>

--- a/tests/test_app_static.py
+++ b/tests/test_app_static.py
@@ -1,0 +1,17 @@
+from starlette.testclient import TestClient
+from app.main import app
+
+
+def test_index_served():
+    client = TestClient(app)
+    response = client.get('/')
+    assert response.status_code == 200
+    assert 'text/html' in response.headers.get('content-type', '')
+
+
+def test_static_files_served():
+    client = TestClient(app)
+    response = client.get('/static/style.css')
+    assert response.status_code == 200
+    assert 'text/css' in response.headers.get('content-type', '')
+    assert len(response.text) > 0


### PR DESCRIPTION
## Summary
- mount FastAPI StaticFiles for CSS & JS
- reference /static in the html
- add tests to ensure index and static files are served

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f08431b10832c9988f9f6c8cf0159