### PR TITLE
Fix docker build failure and add test

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:latest
+FROM ubuntu:22.04
 
 RUN apt-get update && \
     apt-get install -y python3 python3-pip curl unzip && \

--- a/tests/test_dockerfile.py
+++ b/tests/test_dockerfile.py
@@ -1,0 +1,9 @@
+import re
+from pathlib import Path
+
+
+def test_dockerfile_base_image():
+    dockerfile_path = Path('Dockerfile')
+    content = dockerfile_path.read_text()
+    first_line = content.splitlines()[0]
+    assert first_line == 'FROM ubuntu:22.04', f"Base image should be ubuntu:22.04, got: {first_line}"


### PR DESCRIPTION
## Summary
- pin base image to `ubuntu:22.04` for more stable package installs
- verify the Dockerfile base image with a new unit test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686fe0e841b4832c824501a05e893349