### PR TITLE
Enable async streaming of terminal output

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -58,12 +58,18 @@ async def websocket_endpoint(websocket: WebSocket):
             if msg.get("type") == "chat_message":
                 user_msg = msg.get("content", "")
 
+                loop = asyncio.get_running_loop()
+
                 def stream_cb(text: str):
-                    asyncio.create_task(
-                        websocket.send_text(json.dumps({"type": "terminal_data", "content": text}))
+                    loop.create_task(
+                        websocket.send_text(
+                            json.dumps({"type": "terminal_data", "content": text})
+                        )
                     )
 
-                ai_response = ai_agent.chat(user_msg, stream_callback=stream_cb)
+                ai_response = await asyncio.to_thread(
+                    ai_agent.chat, user_msg, stream_callback=stream_cb
+                )
                 await websocket.send_text(
                     json.dumps({"type": "chat_message", "content": ai_response})
                 )

--- a/tests/test_ai_agent.py
+++ b/tests/test_ai_agent.py
@@ -55,7 +55,7 @@ def test_ai_agent_chat_runs_command(monkeypatch):
     response2 = DummyResponse(DummyMessage(content='done'))
     dummy_client = DummyOpenAI([response1, response2])
     monkeypatch.setattr('openai.OpenAI', lambda api_key, base_url=None: dummy_client)
-    agent = AIAgent(dm, api_key='test')
+    agent = AIAgent(dm, None, api_key='test')
     captured = []
 
     def cb(data):
@@ -81,6 +81,6 @@ def test_ai_agent_chat_handles_error(monkeypatch):
             self.chat = type('chat', (), {'completions': ErrorCompletions()})
 
     monkeypatch.setattr('openai.OpenAI', lambda api_key, base_url=None: ErrorClient())
-    agent = AIAgent(dm, api_key='test')
+    agent = AIAgent(dm, None, api_key='test')
     result = agent.chat('hi')
     assert result.startswith('Error communicating with language model')

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -10,3 +10,30 @@ def test_websocket_invalid_json():
         data = json.loads(websocket.receive_text())
         assert data['type'] == 'error'
         assert 'Invalid JSON' in data['content']
+
+
+def test_websocket_streams_responses(monkeypatch):
+    class DummyAgent:
+        def chat(self, message, stream_callback=None):
+            if stream_callback:
+                stream_callback('partial')
+            import time
+            time.sleep(0.01)
+            return 'done'
+
+    monkeypatch.setattr('app.main.ai_agent', DummyAgent())
+
+    client = TestClient(app)
+    with client.websocket_connect('/ws') as websocket:
+        websocket.send_text(json.dumps({'type': 'chat_message', 'content': 'hi'}))
+        messages = [json.loads(websocket.receive_text()) for _ in range(2)]
+
+        types = {m['type'] for m in messages}
+        assert 'terminal_data' in types
+        assert 'chat_message' in types
+
+        term_msg = next(m for m in messages if m['type'] == 'terminal_data')
+        chat_msg = next(m for m in messages if m['type'] == 'chat_message')
+
+        assert term_msg['content'] == 'partial'
+        assert chat_msg['content'] == 'done'


### PR DESCRIPTION
## Summary
- execute ai_agent.chat in a background thread so WebSocket callbacks don't block
- use the running loop to schedule stream callbacks
- add regression test verifying streamed data is sent over the socket
- adjust AIAgent tests to pass dummy internet tools

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870601341c0832ca210e069254c0a44